### PR TITLE
All counters can be used before `cantal.start()` (are no-op)

### DIFF
--- a/cantal/core.py
+++ b/cantal/core.py
@@ -1,6 +1,7 @@
 import abc
 
 from . import collection as _collection
+from .py2_compat import MemoryView
 
 
 class _Value(object):
@@ -13,6 +14,14 @@ class _Value(object):
         if collection is None:
             collection = _collection.global_collection
         collection.add(kwargs, self)
+
+        # Create temporary view, this is useful if you enter some branch of
+        # code in unusual code path such as ipython shell or management
+        # commands. Counters are not useful in this case but should not crash,
+        # so you don't need a lot of `if` statements
+        vtype, _ = self._get_type()
+        size = self._get_size()
+        self._memoryview = MemoryView(bytearray(size)).cast(vtype)
 
     @abc.abstractmethod
     def _get_size(self):

--- a/cantal/core.py
+++ b/cantal/core.py
@@ -5,7 +5,7 @@ from .py2_compat import MemoryView
 
 
 class _Value(object):
-    __slots__ = ()
+    __slots__ = ('_memoryview',)
 
     def __init__(self, *args, **kwargs):
         if args:

--- a/cantal/counters.py
+++ b/cantal/counters.py
@@ -2,7 +2,7 @@ from .core import _Value
 
 
 class Counter(_Value):
-    __slots__ = ('_memoryview')
+    __slots__ = ()
 
     def __iadd__(self, value):
         self._memoryview[0] += value

--- a/cantal/levels.py
+++ b/cantal/levels.py
@@ -2,7 +2,7 @@ from .core import _Value
 
 
 class Float(_Value):
-    __slots__ = ('_memoryview')
+    __slots__ = ()
 
     def incr(self, value=1):
         self._memoryview[0] = value
@@ -24,7 +24,7 @@ class Float(_Value):
 
 
 class Integer(_Value):
-    __slots__ = ('_memoryview')
+    __slots__ = ()
 
     def _get_size(self):
         return 8

--- a/cantal/py2_compat.py
+++ b/cantal/py2_compat.py
@@ -27,7 +27,10 @@ else:
             return MemoryView(self._mmap, item)
 
         def cast(self, typ):
-            start, stop, step = self._slice.indices(len(self._mmap))
+            slc = self._slice
+            if slc is None:
+                slc = slice(None)  # full slice
+            start, stop, step = slc.indices(len(self._mmap))
             assert step == 1, 'Only step 1 supported'
             bytesize = struct.calcsize(typ)
             _typ = TYPEMAP[typ] * ((stop - start) // bytesize)

--- a/cantal/simple_state.py
+++ b/cantal/simple_state.py
@@ -11,7 +11,7 @@ _timestr = struct.Struct('L')
 
 
 class State(_Value):
-    __slots__ = ('_memoryview', 'size')
+    __slots__ = ('size',)
     HEADER_SIZE = _timestr.size
     assert HEADER_SIZE == 8, 'We use constants in enter/exit/context'
 

--- a/tests/test_no_start.py
+++ b/tests/test_no_start.py
@@ -1,0 +1,21 @@
+from cantal import Collection, Counter, Integer, State
+from unittest import TestCase
+
+
+class NoCrashWithoutStart(TestCase):
+
+    def setUp(self):
+        self.collection = Collection()
+
+    def test_counter(self):
+        cnt = Counter(collection=self.collection, hello="world")
+        cnt.incr(1)
+
+    def test_integer(self):
+        val = Integer(collection=self.collection, hello="world")
+        val.incr(1)
+
+    def test_state(self):
+        val = State(collection=self.collection, hello="world")
+        val.enter('Nice work!')
+        val.exit()

--- a/tests/test_no_start.py
+++ b/tests/test_no_start.py
@@ -19,3 +19,9 @@ class NoCrashWithoutStart(TestCase):
         val = State(collection=self.collection, hello="world")
         val.enter('Nice work!')
         val.exit()
+
+    def test_after_start(self):
+        cnt = Counter(collection=self.collection, hello="world")
+        collection = self.collection.start('/tmp/test.cantal')
+        with self.assertRaises(RuntimeError):
+            cnt2 = Counter(collection=collection, hello="world")


### PR DESCRIPTION
This is implemented so that it has no additional overhead on the hot path

/cc @popravich
