### PR TITLE
Use monotonic clock for duration tracking

### DIFF
--- a/cantal/clock.py
+++ b/cantal/clock.py
@@ -1,0 +1,8 @@
+import time
+
+
+try:
+    monotonic = time.perf_counter
+except AttributeError:
+    # Python 3.2 and below
+    monotonic = time.clock

--- a/cantal/collection.py
+++ b/cantal/collection.py
@@ -65,8 +65,6 @@ class Collection(object):
                 _, typ = value._get_type()
                 scheme.append(typ + ': ' + name)
 
-        size = offset
-
         path = basepath + '.values'
         tmppath = basepath + '.tmp'
         metapath = basepath + '.meta'

--- a/cantal/core.py
+++ b/cantal/core.py
@@ -1,5 +1,4 @@
 import abc
-import sys
 import logging
 
 from . import collection as _collection
@@ -33,4 +32,8 @@ class _Value(object):
 
     @abc.abstractmethod
     def _get_size(self):
+        pass
+
+    @abc.abstractmethod
+    def _get_type(self):
         pass

--- a/cantal/fork.py
+++ b/cantal/fork.py
@@ -1,11 +1,10 @@
-import time
-import sys
 import logging
 import traceback
 from contextlib import contextmanager
 
 from .simple_state import State
 from .counters import Counter
+from .clock import monotonic
 
 
 log = logging.getLogger(__name__)
@@ -51,16 +50,16 @@ class Fork(object):
         try:
             yield
         finally:
-            ts = int(time.time()*1000)
+            ts = int(monotonic() * 1000)
             if self._branch is not None:
                 self._branch._commit(self._timestamp, ts)
             self._state.exit()
             self._branch = None
 
     def enter_branch(self, branch):
-        ts = int(time.time()*1000)
+        ts = int(monotonic() * 1000)
         if self._branch is not None:
             self._branch._commit(self._timestamp, ts)
-        self._state.enter(branch.name, _timestamp=ts)
+        self._state.enter(branch.name)
         self._timestamp = ts
         self._branch = branch

--- a/cantal/req.py
+++ b/cantal/req.py
@@ -1,8 +1,8 @@
-import time
 from contextlib import contextmanager
 
 from .counters import Counter
 from .levels import Integer
+from .clock import monotonic
 
 
 class RequestTracker(object):
@@ -18,7 +18,7 @@ class RequestTracker(object):
 
     @contextmanager
     def request(self):
-        start = time.time()
+        start = monotonic()
         self.in_progress.incr()
         try:
             yield
@@ -26,7 +26,7 @@ class RequestTracker(object):
             self.errors.incr()
             raise
         finally:
-            dur = time.time() - start
+            dur = monotonic() - start
             self.in_progress.decr()
             self.requests.incr()
             self.duration.incr(int(dur * 1000))

--- a/cantal/simple_state.py
+++ b/cantal/simple_state.py
@@ -32,11 +32,8 @@ class State(_Value):
     def _get_type(self):
         return ('B', 'state {}'.format(self.size + self.HEADER_SIZE))
 
-    def enter(self, value, _timestamp=None):
+    def enter(self, value):
         """Enter a state with a value
-
-        The _timestamp is a merely optimization, don't pass it in any user
-        code
         """
         encoded = value.encode('utf-8')
         le = len(encoded)
@@ -47,9 +44,8 @@ class State(_Value):
         elif tail > 0:
             encoded = encoded[:self.size]
         le += 8
-        if _timestamp is None:
-            _timestamp = int(time.time()*1000)
-        chunk = _timestr.pack(_timestamp) + encoded
+        timestamp = int(time.time()*1000)
+        chunk = _timestr.pack(timestamp) + encoded
         self._memoryview[0:le] = chunk
 
     @contextmanager


### PR DESCRIPTION
Using `time.time()` for duration tracking
had the downside that duration could turn out
negative if system time changed in between.
Consequently, negative duration was the cause
of runtime exception in `Counter.incr` because negative
values are not compatible with `'Q'` struct type.

I also had to remove `_timestamp` param in `State.enter` since it's not possible to reuse it anymore.
I couldn't come up with a way to test this unfortunately.