### PR TITLE
Fix invalid `warnings` module attribute

### DIFF
--- a/cantal/simple_state.py
+++ b/cantal/simple_state.py
@@ -18,7 +18,7 @@ class State(_Value):
     def __init__(self, size=CACHE_LINE_SIZE-HEADER_SIZE, **kwargs):
         sz = size + self.HEADER_SIZE
         if sz & (sz - 1) or sz % CACHE_LINE_SIZE:
-            warnings.warning(
+            warnings.warn(
                 "Size of state counter should be multiple of {} or smaller"
                 "power of two sans header size ({}), perfect size is {}"
                 .format(CACHE_LINE_SIZE, self.HEADER_SIZE,

--- a/tests/test_stats.py
+++ b/tests/test_stats.py
@@ -1,6 +1,7 @@
 import os
 import struct
 import textwrap
+import warnings
 from cantal import Collection, Counter, Float, Integer, State, Fork
 from unittest import TestCase
 
@@ -95,6 +96,14 @@ class TestValues(TestBase):
         with state.context('short'):
             self.assertRead(b'short\x00onger_job_name' + b'\x00'*36, 8)
         self.assertRead(b'\x00'*8 + b'short\x00onger_job_name' + b'\x00'*36)
+
+    def test_state_warns_on_odd_size(self):
+        with warnings.catch_warnings(record=True) as ws:
+            warnings.simplefilter("always")
+
+            State(101)
+
+            self.assertEquals(1, len(ws))
 
 
 class TestScheme(TestBase):


### PR DESCRIPTION
It's `warnings.warn`, not `warnings.warning`.